### PR TITLE
Feature / Limit the number of scores in the feed

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.order(played_at: :desc, id: :desc).limit(25)
       serialized_scores = scores.map(&:serialize)
 
       response = {

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -28,6 +28,23 @@ describe Api::ScoresController, type: :request do
     end
   end
 
+  describe 'GET user_feed' do
+    it 'should limit the feed to 25 scores' do
+      30.times do
+        create(:score, user: @user1, total_score: 79, played_at: '2021-05-20')
+      end
+
+      get api_feed_path
+
+      expect(response).to have_http_status(:ok)
+
+      response_hash = JSON.parse(response.body)
+      scores = response_hash['scores']
+
+      expect(scores.length).to eq(25)
+    end
+  end
+
   describe 'POST create' do
     it 'should save and return the new score if valid parameters' do
       score_count = Score.count

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -42,6 +42,8 @@ describe Api::ScoresController, type: :request do
       scores = response_hash['scores']
 
       expect(scores.length).to eq(25)
+      expect(scores[0]['played_at']).to eq '2021-06-20'
+      expect(scores[24]['played_at']).to eq '2021-05-20'
     end
   end
 


### PR DESCRIPTION
Fixes: https://github.com/AACraiu/golfr_backend/issues/21

**Changes**

Added a test to verify that the feed is limited to 25 scores, added .limit(25) to user_feed

**Before**

![Image 16 10 2023 at 03 56](https://github.com/gabrielsorin88/golfr_backend/assets/126314730/3138431a-d6b4-416c-a7fa-2e57d8e4f9e8)


**After**

![Image 16 10 2023 at 03 59](https://github.com/gabrielsorin88/golfr_backend/assets/126314730/18c1001d-bff7-4b98-9b98-90b874bec97f)

